### PR TITLE
Revert "3.0.0 (#20)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.0.0]
-
 ### Added
 
-- Newly exports the following types: `AnyStruct`, `EnumSchema`, `InferStructTuple`, `IsExactMatch`, `IsMatch`, `IsRecord`, `IsTuple`, `ObjectSchema`, `OmitBy`, `Optionalize`, `PickBy`, `Simplify`, `UnionToIntersection` ([#18](https://github.com/MetaMask/superstruct/pull/18))
-
-### Fixed
-
-- **BREAKING:** Expose separate build entry points and type declarations for CommonJS and ESM via package manifest `exports` ([#18](https://github.com/MetaMask/superstruct/pull/18)).
+- Newly exports the following types: `AnyStruct`, `EnumSchema`, `InferStructTuple`, `IsExactMatch`, `IsMatch`, `IsRecord`, `IsTuple`, `ObjectSchema`, `OmitBy`, `Optionalize`, `PickBy`, `Simplify`, `UnionToIntersection`.
 
 ## [2.0.0]
 
@@ -623,8 +617,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/MetaMask/superstruct/compare/v3.0.0...HEAD
-[3.0.0]: https://github.com/MetaMask/superstruct/compare/v2.0.0...v3.0.0
+[Unreleased]: https://github.com/MetaMask/superstruct/compare/v2.0.0...HEAD
 [2.0.0]: https://github.com/MetaMask/superstruct/compare/v1.0.0...v2.0.0
 [1.0.0]: https://github.com/MetaMask/superstruct/compare/v0.16.0...v1.0.0
 [0.16.0]: https://github.com/MetaMask/superstruct/compare/v0.15.0...v0.16.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/superstruct",
-  "version": "3.0.0",
+  "version": "2.0.0",
   "description": "A simple and composable way to validate data in JavaScript (and TypeScript).",
   "keywords": [
     "api",


### PR DESCRIPTION
This reverts commit 545c215e5f4b1f8fe5e700842d67fff542eed0a2.

The previous release PR for 3.0.0 wasn't generated by manually triggering the `create-release-pr` workflow, resulting in a failure to publish.