### PR TITLE
Add all types in the `utils` submodule as package-level exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Newly exports the following types: `Assign`, `If`, `IsUnion`, `ObjectType`, `PartialObjectSchema`, `StructSchema`, `TupleSchema`
+
 ## [3.0.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Newly exports the following types: `Assign`, `If`, `IsUnion`, `ObjectType`, `PartialObjectSchema`, `StructSchema`, `TupleSchema`
+- Newly exports the following types: `Assign`, `If`, `IsUnion`, `ObjectType`, `PartialObjectSchema`, `StructSchema`, `TupleSchema` ([#25](https://github.com/MetaMask/superstruct/pull/25)).
 
 ## [3.0.0]
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,16 +6,23 @@ export * from './structs/types.js';
 export * from './structs/utilities.js';
 export type {
   AnyStruct,
+  Assign,
   EnumSchema,
+  If,
   InferStructTuple,
   IsExactMatch,
   IsMatch,
   IsRecord,
   IsTuple,
+  IsUnion,
   ObjectSchema,
+  ObjectType,
   OmitBy,
   Optionalize,
+  PartialObjectSchema,
   PickBy,
   Simplify,
+  StructSchema,
+  TupleSchema,
   UnionToIntersection,
 } from './utils.js';


### PR DESCRIPTION
## Motivation

`snaps` repos have continued to expand its usage of `utils` types in the `superstruct` package. 

Unfortunately, the workaround of importing from `superstruct/dist/utils` is no longer available in the `@metamask/superstruct` fork, so importing new `utils` types will require new version releases going forward.

To prevent this from blocking downstream development, this commit adds all currently available types in the `utils` submodule as package-level exports.

## Description

- Newly exports the following types: `Assign`, `If`, `IsUnion`, `ObjectType`, `PartialObjectSchema`, `StructSchema`, `TupleSchema`

## References

- Closes https://github.com/MetaMask/superstruct/issues/26
- Blocking https://github.com/MetaMask/snaps/pull/2445
  - Blocking https://github.com/MetaMask/snaps/pull/2514