### PR TITLE
Remove unreleased changelog entry to unblock release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- Newly exports the following types: `Assign`, `If`, `IsUnion`, `ObjectType`, `PartialObjectSchema`, `StructSchema`, `TupleSchema` ([#25](https://github.com/MetaMask/superstruct/pull/25)).
-
 ## [3.0.0]
 
 ### Added


### PR DESCRIPTION
- `create-release-pr` action is failing due to this issue: https://github.com/MetaMask/action-create-release-pr/issues/138
- Removing unreleased changelog entries should unblock this, enabling a release candidate to be created.