### PR TITLE
Fix `ExactOptionalize` changing `never` to `undefined`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -362,7 +362,9 @@ type OmitExactOptional<Schema extends ObjectSchema> = Omit<
   Schema,
   {
     [K in keyof Schema]: Schema[K] extends ExactOptionalStruct<any, any>
-      ? K
+      ? Schema[K] extends never
+        ? never
+        : K
       : never;
   }[keyof Schema]
 >;
@@ -371,7 +373,9 @@ type PickExactOptional<Schema extends ObjectSchema> = Pick<
   Schema,
   {
     [K in keyof Schema]: Schema[K] extends ExactOptionalStruct<any, any>
-      ? K
+      ? Schema[K] extends never
+        ? never
+        : K
       : never;
   }[keyof Schema]
 >;

--- a/test/typings/exactOptional.ts
+++ b/test/typings/exactOptional.ts
@@ -5,6 +5,8 @@ import {
   number,
   object,
   enums,
+  never,
+  record,
 } from '../../src';
 import { test } from '../index.test';
 
@@ -42,6 +44,18 @@ test<{
           g: exactOptional(object({ h: string() })),
         }),
       ),
+    }),
+  );
+  return value;
+});
+
+test<{
+  a?: Record<string, never>;
+}>((value) => {
+  assert(
+    value,
+    object({
+      a: exactOptional(record(string(), never())),
     }),
   );
   return value;

--- a/test/typings/object.ts
+++ b/test/typings/object.ts
@@ -1,4 +1,4 @@
-import { assert, object, number, string } from '../../src';
+import { assert, object, number, string, record, never } from '../../src';
 import { test } from '../index.test';
 
 test<Record<string, unknown>>((value) => {
@@ -11,5 +11,17 @@ test<{
   b: string;
 }>((value) => {
   assert(value, object({ a: number(), b: string() }));
+  return value;
+});
+
+test<{
+  a: Record<string, never>;
+}>((value) => {
+  assert(
+    value,
+    object({
+      a: record(string(), never()),
+    }),
+  );
   return value;
 });


### PR DESCRIPTION
`never` is a subtype of all types, so in this case, if `Schema[K]` is never, `K` is used:

```ts
Schema[K] extends ExactOptionalStruct<any, any> ? K : never;
```

This is problematic when using a struct type like `Record<string, never>`. This was previously incorrectly changed into `Record<string, undefined>`. After this change, the type is not affected.